### PR TITLE
Remove HashProvider and deprecate it

### DIFF
--- a/src/main/php/util/collections/DJBX33AHashImplementation.class.php
+++ b/src/main/php/util/collections/DJBX33AHashImplementation.class.php
@@ -31,6 +31,7 @@
  *
  * -- Ralf S. Engelschall
  *
+ * @deprecated
  * @see  xp://util.collections.HashProvider
  * @test xp://net.xp_framework.unittest.util.collections.DJBX33AHashImplementationTest:
  */

--- a/src/main/php/util/collections/HashImplementation.class.php
+++ b/src/main/php/util/collections/HashImplementation.class.php
@@ -3,6 +3,7 @@
 /**
  * Hash implementation
  *
+ * @deprecated
  * @see   xp://util.collections.HashProvider
  */
 interface HashImplementation {

--- a/src/main/php/util/collections/HashProvider.class.php
+++ b/src/main/php/util/collections/HashProvider.class.php
@@ -16,6 +16,7 @@
  *   HashProvider::getInstance()->setImplementation(new MyHashImplementation());
  * ```
  * 
+ * @deprecated
  * @see   xp://util.collections.DJBX33AHashImplementation
  * @see   xp://util.collections.MD5HashImplementation
  * @see   xp://util.collections.Map

--- a/src/main/php/util/collections/HashSet.class.php
+++ b/src/main/php/util/collections/HashSet.class.php
@@ -98,7 +98,6 @@ class HashSet extends \lang\Object implements Set {
     $h= Objects::hashOf($element);
     if (isset($this->_elements[$h])) return false;
     
-    $this->_hash+= HashProvider::hashOf($h);
     $this->_elements[$h]= $element;
     return true;
   }
@@ -114,7 +113,6 @@ class HashSet extends \lang\Object implements Set {
     $h= Objects::hashOf($element);
     if (!isset($this->_elements[$h])) return false;
 
-    $this->_hash-= HashProvider::hashOf($h);
     unset($this->_elements[$h]);
     return true;
   }
@@ -147,7 +145,6 @@ class HashSet extends \lang\Object implements Set {
    */
   public function clear() { 
     $this->_elements= [];
-    $this->_hash= 0;
   }
 
   /**
@@ -172,7 +169,6 @@ class HashSet extends \lang\Object implements Set {
       $h= Objects::hashOf($element);
       if (isset($this->_elements[$h])) continue;
 
-      $this->_hash+= HashProvider::hashOf($h);
       $this->_elements[$h]= $element;
       $changed= true;
     }
@@ -195,17 +191,21 @@ class HashSet extends \lang\Object implements Set {
    * @return  string
    */
   public function hashCode() {
-    return $this->_hash;
+    $hash= '';
+    foreach ($this->_elements as $element) {
+      $hash.= Objects::hashOf($element);
+    }
+    return md5($hash);
   }
   
   /**
    * Returns true if this set equals another set.
    *
-   * @param   lang.Generic cmp
+   * @param   var cmp
    * @return  bool
    */
   public function equals($cmp) {
-    return $cmp instanceof self && $this->_hash === $cmp->_hash;
+    return $cmp instanceof self && $this->hashCode() === $cmp->hashCode();
   }
 
   /**
@@ -219,7 +219,7 @@ class HashSet extends \lang\Object implements Set {
 
     $s.= "\n";
     foreach ($this->_elements as $e) {
-      $s.= '  '.\xp::stringOf($e).",\n";
+      $s.= '  '.Objects::stringOf($e).",\n";
     }
     return substr($s, 0, -2)."\n}";
   }

--- a/src/main/php/util/collections/HashTable.class.php
+++ b/src/main/php/util/collections/HashTable.class.php
@@ -15,12 +15,8 @@ use lang\Generic;
  */
 #[@generic(self= 'K, V', implements= ['K, V'])]
 class HashTable extends \lang\Object implements Map, \IteratorAggregate {
-  protected static
-    $iterate   = null;
-
-  protected
-    $_buckets  = [],
-    $_hash     = 0;
+  protected static $iterate= null;
+  protected $_buckets= [];
 
   static function __static() {
     self::$iterate= newinstance('Iterator', [], '{
@@ -109,7 +105,6 @@ class HashTable extends \lang\Object implements Map, \IteratorAggregate {
     }
 
     $this->_buckets[$h]= [$key, $value];
-    $this->_hash+= HashProvider::hashOf($h.Objects::hashOf($value));
     return $previous;
   }
 
@@ -141,7 +136,6 @@ class HashTable extends \lang\Object implements Map, \IteratorAggregate {
       $prev= null;
     } else {
       $prev= $this->_buckets[$h][1];
-      $this->_hash-= HashProvider::hashOf($h.Objects::hashOf($prev));
       unset($this->_buckets[$h]);
     }
 
@@ -155,7 +149,6 @@ class HashTable extends \lang\Object implements Map, \IteratorAggregate {
    */
   public function clear() {
     $this->_buckets= [];
-    $this->_hash= 0;
   }
 
   /**
@@ -218,7 +211,11 @@ class HashTable extends \lang\Object implements Map, \IteratorAggregate {
    * @return  string
    */
   public function hashCode() {
-    return $this->_hash;
+    $hash= '';
+    foreach ($this->_buckets as $key => $value) {
+      $hash.= $key.Objects::hashOf($value[1]);
+    }
+    return md5($hash);
   }
   
   /**
@@ -228,7 +225,7 @@ class HashTable extends \lang\Object implements Map, \IteratorAggregate {
    * @return  bool
    */
   public function equals($cmp) {
-    return $cmp instanceof self && $this->_hash === $cmp->_hash;
+    return $cmp instanceof self && $this->hashCode() === $cmp->hashCode();
   }
   
   /**
@@ -270,7 +267,7 @@ class HashTable extends \lang\Object implements Map, \IteratorAggregate {
 
     $s.= "\n";
     foreach ($this->_buckets as $b) {
-      $s.= '  '.\xp::stringOf($b[0]).' => '.\xp::stringOf($b[1]).",\n";
+      $s.= '  '.Objects::stringOf($b[0]).' => '.Objects::stringOf($b[1]).",\n";
     }
     return substr($s, 0, -2)."\n}";
   }

--- a/src/main/php/util/collections/MD5HashImplementation.class.php
+++ b/src/main/php/util/collections/MD5HashImplementation.class.php
@@ -3,6 +3,7 @@
 /**
  * MD5
  *
+ * @deprecated
  * @see   php://md5
  * @see   xp://util.collections.HashProvider
  * @test  xp://net.xp_framework.unittest.util.collections.MD5HashImplementationTest:

--- a/src/main/php/util/collections/MD5HexHashImplementation.class.php
+++ b/src/main/php/util/collections/MD5HexHashImplementation.class.php
@@ -12,6 +12,7 @@
  * // 5.2.10: float(2.4057803815529E+37)
  * ```
  *
+ * @deprecated
  * @see   php://md5
  * @see   php://hexdec
  * @see   xp://util.collections.HashProvider

--- a/src/main/php/util/collections/Map.class.php
+++ b/src/main/php/util/collections/Map.class.php
@@ -3,8 +3,6 @@
 /**
  * An object that maps keys to values. A map cannot contain duplicate 
  * keys; each key can map to at most one value. 
- *
- * @see   xp://util.collections.HashProvider
  */
 #[@generic(self= 'K, V')]
 interface Map extends \ArrayAccess {

--- a/src/main/php/util/collections/Pair.class.php
+++ b/src/main/php/util/collections/Pair.class.php
@@ -43,10 +43,7 @@ class Pair extends \lang\Object {
    * @return string
    */
   public function hashCode() {
-    return (
-      HashProvider::hashOf(Objects::hashOf($this->key)) +
-      HashProvider::hashOf(Objects::hashOf($this->value))
-    );
+    return md5(Objects::hashOf($this->key).Objects::hashOf($this->value));
   }
 
   /**

--- a/src/main/php/util/collections/Queue.class.php
+++ b/src/main/php/util/collections/Queue.class.php
@@ -34,9 +34,7 @@ use lang\Value;
  */
 #[@generic(self= 'T')]
 class Queue extends \lang\Object {
-  protected
-    $_elements = [],
-    $_hash     = 0;
+  protected $_elements= [];
 
   /**
    * Puts an item into the queue. Returns the element that was added.
@@ -46,9 +44,7 @@ class Queue extends \lang\Object {
    */
   #[@generic(params= 'T', return= 'T')]
   public function put($element) {
-    $h= Objects::hashOf($element);
     $this->_elements[]= $element;
-    $this->_hash+= HashProvider::hashOf($h);
     return $element;
   }
 
@@ -65,8 +61,6 @@ class Queue extends \lang\Object {
     }
 
     $element= $this->_elements[0];
-    $h= Objects::hashOf($element);
-    $this->_hash-= HashProvider::hashOf($h);
     $this->_elements= array_slice($this->_elements, 1);
     return $element;
   }
@@ -124,11 +118,8 @@ class Queue extends \lang\Object {
    */
   #[@generic(params= 'T')]
   public function remove($element) {
-    if (-1 == ($pos= $this->search($element))) return false;
+    if (-1 === ($pos= $this->search($element))) return false;
 
-    $element= $this->_elements[$pos];
-    $h= Objects::hashOf($element);
-    $this->_hash-= HashProvider::hashOf($h);
     unset($this->_elements[$pos]);
     $this->_elements= array_values($this->_elements);   // Re-index
     return true;
@@ -155,16 +146,20 @@ class Queue extends \lang\Object {
    * @return  string
    */
   public function hashCode() {
-    return $this->_hash;
+    $hash= '';
+    foreach ($this->_elements as $element) {
+      $hash.= Objects::hashOf($element);
+    }
+    return md5($hash);
   }
   
   /**
    * Returns true if this queue equals another queue.
    *
-   * @param   lang.Generic cmp
+   * @param   var cmp
    * @return  bool
    */
   public function equals($cmp) {
-    return $cmp instanceof self && $this->_hash === $cmp->_hash;
+    return $cmp instanceof self && $this->hashCode() === $cmp->hashCode();
   }
 }

--- a/src/main/php/util/collections/Stack.class.php
+++ b/src/main/php/util/collections/Stack.class.php
@@ -35,9 +35,7 @@ use util\Objects;
  */
 #[@generic(self= 'T')]
 class Stack extends \lang\Object {
-  protected
-    $_elements = [],
-    $_hash     = 0;
+  protected $_elements= [];
 
   /**
    * Pushes an item onto the top of the stack. Returns the element that 
@@ -48,9 +46,7 @@ class Stack extends \lang\Object {
    */
   #[@generic(params= 'T', return= 'T')]
   public function push($element) {
-    $h= Objects::hashOf($element);
     array_unshift($this->_elements, $element);
-    $this->_hash+= HashProvider::hashOf($h);
     return $element;
   }
 
@@ -66,8 +62,6 @@ class Stack extends \lang\Object {
       throw new NoSuchElementException('Stack is empty');
     }
     $element= array_shift($this->_elements);
-    $h= Objects::hashOf($element);
-    $this->_hash+= HashProvider::hashOf($h);
     return $element;
   }
 
@@ -136,16 +130,20 @@ class Stack extends \lang\Object {
    * @return  string
    */
   public function hashCode() {
-    return $this->_hash;
+    $hash= '';
+    foreach ($this->_elements as $element) {
+      $hash.= Objects::hashOf($element);
+    }
+    return md5($hash);
   }
   
   /**
    * Returns true if this queue equals another queue.
    *
-   * @param   lang.Generic cmp
+   * @param   var cmp
    * @return  bool
    */
   public function equals($cmp) {
-    return $cmp instanceof self && $this->_hash === $cmp->_hash;
+    return $cmp instanceof self && $this->hashCode() === $cmp->hashCode();
   }
 }

--- a/src/main/php/util/collections/Vector.class.php
+++ b/src/main/php/util/collections/Vector.class.php
@@ -316,7 +316,7 @@ class Vector extends \lang\Object implements IList {
   /**
    * Checks if a specified object is equal to this object.
    *
-   * @param   lang.Generic collection
+   * @param   var cmp
    * @return  bool
    */
   public function equals($cmp) {

--- a/src/test/php/util/collections/unittest/HashProviderTest.class.php
+++ b/src/test/php/util/collections/unittest/HashProviderTest.class.php
@@ -7,6 +7,7 @@ use util\collections\HashImplementation;
 /**
  * Test HashProvider class
  *
+ * @deprecated
  * @see  xp://util.collections.HashProvider
  */
 class HashProviderTest extends TestCase {

--- a/src/test/php/util/collections/unittest/HashTableTest.class.php
+++ b/src/test/php/util/collections/unittest/HashTableTest.class.php
@@ -87,13 +87,6 @@ class HashTableTest extends \unittest\TestCase {
     $this->assertEquals(1, $object->invoked);
   }
 
-  #[@test, @values('variations')]
-  public function put_uses_hashCode_for_values($fixture) {
-    $object= $this->hashCodeCounter();
-    $fixture->put($this, $object);
-    $this->assertEquals(1, $object->invoked);
-  }
-
   #[@test, @values('fixtures')]
   public function array_access_for_writing($fixture, $pairs) {
     $fixture[$pairs[0]->key]= $pairs[0]->value;


### PR DESCRIPTION
This pull request changes the way hashcodes are computed for `HashTable`, `HashSet`, `Queue` and `Stack`. Instead of keeping track of the hashcode when writing, it is computed when `hashCode()` is invoked, which occurs much less often!

This yields a speedup factor between 2 and 4 - see [this measuring code](https://gist.github.com/thekid/4a3e9f5b51aa140218468ca8b922d223):

```bash
# Before
$ xp -m ..\measure\ util.profiling.Measure Collections -n 100000
hashTable: 100000 iteration(s), 0.674 seconds, result= "value"
hashSet: 100000 iteration(s), 0.458 seconds, result= 1
queue: 100000 iteration(s), 0.576 seconds, result= "green"
stack: 100000 iteration(s), 0.404 seconds, result= "green"

# After
$ xp -m ..\measure\ util.profiling.Measure Collections -n 100000
hashTable: 100000 iteration(s), 0.332 seconds, result= "value"
hashSet: 100000 iteration(s), 0.249 seconds, result= 1
queue: 100000 iteration(s), 0.135 seconds, result= "green"
stack: 100000 iteration(s), 0.097 seconds, result= "green"
```

This pull request does not introduce a BC break. However, future major versions will remove the now-deprecated class `HashProvider`. Although it's a purely *internal* class is was not clearly marked as such and might have gotten used.