### PR TITLE
XP9 Compatibility 

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,10 @@ Collections change log
 
 ## ?.?.? / ????-??-??
 
+## 8.0.0 / 2017-05-28
+
+* Merged PR #2: Forward compatibility with XP 9.0.0 - @thekid
+
 ## 7.3.0 / 2017-04-23
 
 * Simplified code: Replaced anonymous iterator instances with `yield`

--- a/composer.json
+++ b/composer.json
@@ -6,11 +6,11 @@
   "description" : "Generic collections for the XP Framework",
   "keywords": ["module", "xp"],
   "require" : {
-    "xp-framework/core": "^8.0 | 7.0 | ^6.5",
+    "xp-framework/core": "^9.0 | ^8.0 | 7.0 | ^6.5",
     "php" : ">=5.6.0"
   },
   "require-dev" : {
-    "xp-framework/unittest": "^7.0 | ^6.5"
+    "xp-framework/unittest": "^9.0 | ^8.0 | ^7.0 | ^6.5"
   },
   "autoload" : {
     "files" : ["src/main/php/autoload.php"]

--- a/src/main/php/util/collections/Arrays.class.php
+++ b/src/main/php/util/collections/Arrays.class.php
@@ -13,7 +13,7 @@ use lang\Value;
  * @see   xp://util.collections.IList
  * @see   xp://lang.types.ArrayList
  */
-abstract class Arrays extends \lang\Object {
+abstract class Arrays {
   public static $EMPTY= null;
 
   static function __static() {

--- a/src/main/php/util/collections/DJBX33AHashImplementation.class.php
+++ b/src/main/php/util/collections/DJBX33AHashImplementation.class.php
@@ -35,7 +35,7 @@
  * @see  xp://util.collections.HashProvider
  * @test xp://net.xp_framework.unittest.util.collections.DJBX33AHashImplementationTest:
  */
-class DJBX33AHashImplementation extends \lang\Object implements HashImplementation {
+class DJBX33AHashImplementation implements HashImplementation {
 
   /**
    * Retrieve hash code for a given string

--- a/src/main/php/util/collections/HashProvider.class.php
+++ b/src/main/php/util/collections/HashProvider.class.php
@@ -22,7 +22,7 @@
  * @see   xp://util.collections.Map
  * @test  xp://net.xp_framework.unittest.util.collections.HashProviderTest
  */
-class HashProvider extends \lang\Object {
+class HashProvider {
   protected static
     $instance = null;
 

--- a/src/main/php/util/collections/HashSet.class.php
+++ b/src/main/php/util/collections/HashSet.class.php
@@ -11,7 +11,7 @@ use lang\IllegalArgumentException;
  * @test  xp://net.xp_framework.unittest.util.collections.ArrayAccessTest
  */
 #[@generic(self= 'T', implements= ['T'])]
-class HashSet extends \lang\Object implements Set {
+class HashSet implements Set {
   protected $_elements= [];
 
   /** @return iterable */

--- a/src/main/php/util/collections/HashTable.class.php
+++ b/src/main/php/util/collections/HashTable.class.php
@@ -14,7 +14,7 @@ use lang\Generic;
  * @see   xp://util.collections.Map
  */
 #[@generic(self= 'K, V', implements= ['K, V'])]
-class HashTable extends \lang\Object implements Map, \IteratorAggregate {
+class HashTable implements Map, \lang\Value, \IteratorAggregate {
   protected $_buckets= [];
 
   /** @return iterable */
@@ -187,29 +187,6 @@ class HashTable extends \lang\Object implements Map, \IteratorAggregate {
     }
     return false;
   }
-
-  /**
-   * Returns a hashcode for this map
-   *
-   * @return  string
-   */
-  public function hashCode() {
-    $hash= '';
-    foreach ($this->_buckets as $key => $value) {
-      $hash.= $key.Objects::hashOf($value[1]);
-    }
-    return md5($hash);
-  }
-  
-  /**
-   * Returns true if this map equals another map.
-   *
-   * @param   lang.Generic cmp
-   * @return  bool
-   */
-  public function equals($cmp) {
-    return $cmp instanceof self && $this->hashCode() === $cmp->hashCode();
-  }
   
   /**
    * Returns an array of keys
@@ -238,7 +215,7 @@ class HashTable extends \lang\Object implements Map, \IteratorAggregate {
     }
     return $values;
   }
-  
+
   /**
    * Returns a string representation of this map
    *
@@ -253,5 +230,34 @@ class HashTable extends \lang\Object implements Map, \IteratorAggregate {
       $s.= '  '.Objects::stringOf($b[0]).' => '.Objects::stringOf($b[1]).",\n";
     }
     return substr($s, 0, -2)."\n}";
+  }
+
+  /** Creates a hash code for this object */
+  public function hashCode() {
+    $hash= '';
+    foreach ($this->_buckets as $key => $value) {
+      $hash.= $key.Objects::hashOf($value[1]);
+    }
+    return md5($hash);
+  }
+
+  /**
+   * Compares a specified object to this object.
+   *
+   * @param   var $value
+   * @return  int
+   */
+  public function compareTo($value) {
+    return $value instanceof self ? Objects::compare($this->_buckets, $value->_buckets) : 1;
+  }
+
+  /**
+   * Returns true if this map equals another map.
+   *
+   * @param   var $value
+   * @return  bool
+   */
+  public function equals($value) {
+    return $value instanceof self && Objects::equal($this->_buckets, $value->_buckets);
   }
 }

--- a/src/main/php/util/collections/LRUBuffer.class.php
+++ b/src/main/php/util/collections/LRUBuffer.class.php
@@ -13,7 +13,7 @@ use lang\IllegalArgumentException;
  * @test  xp://net.xp_framework.unittest.util.collections.GenericsTest
  */
 #[@generic(self= 'T')]
-class LRUBuffer extends \lang\Object {
+class LRUBuffer implements \lang\Value {
   protected
     $prefix    = 0,
     $size      = 0,
@@ -106,16 +106,50 @@ class LRUBuffer extends \lang\Object {
   }
 
   /**
-   * Checks if a specified object is equal to this object.
+   * Returns a string representation of this buffer
    *
-   * @param   lang.Generic collection
+   * @return  string
+   */
+  public function toString() {
+    $s= nameof($this).'['.sizeof($this->_elements).'/'.$this->size.'] {';
+    if (empty($this->_elements)) return $s.' }';
+
+    $s.= "\n";
+    foreach ($this->_elements as $e) {
+      $s.= '  '.Objects::stringOf($e).",\n";
+    }
+    return substr($s, 0, -2)."\n}";
+  }
+
+  /** Creates a hash code for this object */
+  public function hashCode() {
+    return 'L'.$this->prefix.$this->size.Objects::hashOf($this->_elements);
+  }
+
+  /**
+   * Compares a specified object to this object.
+   *
+   * @param   var $value
+   * @return  int
+   */
+  public function compareTo($value) {
+    return $value instanceof self
+      ? Objects::compare([$this->size, $this->_elements], [$value->size, $value->_elements])
+      : 1
+    ;
+  }
+
+  /**
+   * Returns true if this map equals another map.
+   *
+   * @param   var $value
    * @return  bool
    */
-  public function equals($cmp) {
-    return (
-      $cmp instanceof self &&
-      $this->size === $cmp->size &&
-      array_keys($this->_elements) === array_keys($cmp->_elements)
-    );
+  public function equals($value) {
+    return 
+      $value instanceof self &&
+      $this->size === $value->size &&
+      Objects::equal($this->_elements, $value->_elements)
+    ;
   }
 }

--- a/src/main/php/util/collections/MD5HashImplementation.class.php
+++ b/src/main/php/util/collections/MD5HashImplementation.class.php
@@ -8,7 +8,7 @@
  * @see   xp://util.collections.HashProvider
  * @test  xp://net.xp_framework.unittest.util.collections.MD5HashImplementationTest:
  */
-class MD5HashImplementation extends \lang\Object implements HashImplementation {
+class MD5HashImplementation implements HashImplementation {
 
   /**
    * Retrieve hash code for a given string

--- a/src/main/php/util/collections/MD5HexHashImplementation.class.php
+++ b/src/main/php/util/collections/MD5HexHashImplementation.class.php
@@ -18,7 +18,7 @@
  * @see   xp://util.collections.HashProvider
  * @test  xp://net.xp_framework.unittest.util.collections.MD5HexHashImplementationTest:
  */
-class MD5HexHashImplementation extends \lang\Object implements HashImplementation {
+class MD5HexHashImplementation implements HashImplementation {
 
   /**
    * Retrieve hash code for a given string

--- a/src/main/php/util/collections/Pair.class.php
+++ b/src/main/php/util/collections/Pair.class.php
@@ -9,7 +9,7 @@ use util\Objects;
  * @test xp://net.xp_framework.unittest.util.collections.PairTest
  */
 #[@generic(self= 'K, V')]
-class Pair extends \lang\Object {
+class Pair implements \lang\Value {
   #[@type('K')]
   public $key;
   #[@type('V')]
@@ -30,11 +30,11 @@ class Pair extends \lang\Object {
   /**
    * Returns whether a given value is equal to this pair
    *
-   * @param  var cmp
-   * @return bool
+   * @param  var $value
+   * @return int
    */
-  public function equals($cmp) {
-    return $cmp instanceof self && Objects::equal($cmp->key, $this->key);
+  public function compareTo($value) {
+    return $value instanceof self ? Objects::compare($this->key, $value->key) : 1;
   }
 
   /**

--- a/src/main/php/util/collections/Queue.class.php
+++ b/src/main/php/util/collections/Queue.class.php
@@ -3,8 +3,6 @@
 use util\Objects;
 use lang\IndexOutOfBoundsException;
 use util\NoSuchElementException;
-use lang\Generic;
-use lang\Value;
 
 /**
  * A First-In-First-Out (FIFO) queue of objects.
@@ -33,7 +31,7 @@ use lang\Value;
  * @see      http://www.faqs.org/docs/javap/c12/ex-12-1-answer.html
  */
 #[@generic(self= 'T')]
-class Queue extends \lang\Object {
+class Queue implements \lang\Value {
   protected $_elements= [];
 
   /**
@@ -141,6 +139,22 @@ class Queue extends \lang\Object {
   }
 
   /**
+   * Returns a string representation of this queue
+   *
+   * @return  string
+   */
+  public function toString() {
+    $s= nameof($this).'['.sizeof($this->_elements).'] {';
+    if (empty($this->_elements)) return $s.' }';
+
+    $s.= "\n";
+    foreach ($this->_elements as $e) {
+      $s.= '  '.Objects::stringOf($e).",\n";
+    }
+    return substr($s, 0, -2)."\n}";
+  }
+
+  /**
    * Returns a hashcode for this queue
    *
    * @return  string
@@ -152,14 +166,24 @@ class Queue extends \lang\Object {
     }
     return md5($hash);
   }
-  
+
   /**
-   * Returns true if this queue equals another queue.
+   * Compares a specified object to this object.
    *
-   * @param   var cmp
+   * @param   var $value
+   * @return  int
+   */
+  public function compareTo($value) {
+    return $value instanceof self ? Objects::compare($this->_elements, $value->_elements) : 1;
+  }
+
+  /**
+   * Returns true if this map equals another value.
+   *
+   * @param   var $value
    * @return  bool
    */
-  public function equals($cmp) {
-    return $cmp instanceof self && $this->hashCode() === $cmp->hashCode();
+  public function equals($value) {
+    return $value instanceof self && Objects::equal($this->_elements, $value->_elements);
   }
 }

--- a/src/main/php/util/collections/Stack.class.php
+++ b/src/main/php/util/collections/Stack.class.php
@@ -2,8 +2,6 @@
 
 use lang\IndexOutOfBoundsException;
 use util\NoSuchElementException;
-use lang\Generic;
-use lang\Value;
 use util\Objects;
 
 /**
@@ -34,7 +32,7 @@ use util\Objects;
  * @see      http://java.sun.com/j2se/1.4.2/docs/api/java/util/Stack.html 
  */
 #[@generic(self= 'T')]
-class Stack extends \lang\Object {
+class Stack implements \lang\Value {
   protected $_elements= [];
 
   /**
@@ -125,7 +123,23 @@ class Stack extends \lang\Object {
   }
 
   /**
-   * Returns a hashcode for this queue
+   * Returns a string representation of this stack
+   *
+   * @return  string
+   */
+  public function toString() {
+    $s= nameof($this).'['.sizeof($this->_elements).'] {';
+    if (empty($this->_elements)) return $s.' }';
+
+    $s.= "\n";
+    foreach ($this->_elements as $e) {
+      $s.= '  '.Objects::stringOf($e).",\n";
+    }
+    return substr($s, 0, -2)."\n}";
+  }
+
+  /**
+   * Returns a hashcode for this stack
    *
    * @return  string
    */
@@ -138,12 +152,22 @@ class Stack extends \lang\Object {
   }
   
   /**
-   * Returns true if this queue equals another queue.
+   * Compares a specified object to this object.
    *
-   * @param   var cmp
+   * @param   var $value
+   * @return  int
+   */
+  public function compareTo($value) {
+    return $value instanceof self ? Objects::compare($this->_elements, $value->_elements) : 1;
+  }
+
+  /**
+   * Returns true if this map equals another value.
+   *
+   * @param   var $value
    * @return  bool
    */
-  public function equals($cmp) {
-    return $cmp instanceof self && $this->hashCode() === $cmp->hashCode();
+  public function equals($value) {
+    return $value instanceof self && Objects::equal($this->_elements, $value->_elements);
   }
 }

--- a/src/main/php/util/collections/Vector.class.php
+++ b/src/main/php/util/collections/Vector.class.php
@@ -1,7 +1,6 @@
 <?php namespace util\collections;
 
-use lang\Generic;
-use lang\Value;
+use util\Objects;
 use lang\IllegalArgumentException;
 use lang\IndexOutOfBoundsException;
 
@@ -14,7 +13,7 @@ use lang\IndexOutOfBoundsException;
  * @see   xp://lang.types.ArrayList
  */
 #[@generic(self= 'T', implements= ['T'])]
-class Vector extends \lang\Object implements IList {
+class Vector implements IList, \lang\Value {
   protected $elements, $size;
 
   /**
@@ -280,11 +279,7 @@ class Vector extends \lang\Object implements IList {
     return false;
   }
   
-  /**
-   * Creates a string representation of this object
-   *
-   * @return  string
-   */
+  /** Creates a string representation of this object */
   public function toString() {
     $r= nameof($this).'['.$this->size."]@{\n";
     foreach ($this->elements as $i => $element) {
@@ -292,22 +287,29 @@ class Vector extends \lang\Object implements IList {
     } 
     return $r.'}';
   }
-  
+
+  /** Creates a hash code for this object */
+  public function hashCode() {
+    return Objects::hashOf($this->elements);
+  }
+
+  /**
+   * Compares a specified object to this object.
+   *
+   * @param   var $value
+   * @return  int
+   */
+  public function compareTo($value) {
+    return $value instanceof self ? Objects::compare($this->elements, $value->elements) : 1;
+  }
+
   /**
    * Checks if a specified object is equal to this object.
    *
-   * @param   var cmp
+   * @param   var $value
    * @return  bool
    */
-  public function equals($cmp) {
-    if (!($cmp instanceof self) || $this->size !== $cmp->size) return false;
-    
-    // Compare element by element
-    foreach ($this->elements as $i => $element) {
-      if ($element instanceof Generic && !$element->equals($cmp->elements[$i])) return false;
-      if ($element instanceof Value && 0 !== $element->compareTo($cmp->elements[$i])) return false;
-      if ($element !== $this->elements[$i]) return false;
-    }
-    return true;
+  public function equals($value) {
+    return $value instanceof self && Objects::equal($this->elements, $value->elements);
   }
 }

--- a/src/test/php/util/collections/unittest/ArrayAccessTest.class.php
+++ b/src/test/php/util/collections/unittest/ArrayAccessTest.class.php
@@ -31,7 +31,7 @@ class ArrayAccessTest extends \unittest\TestCase {
 
   #[@test, @expect(IllegalArgumentException::class)]
   public function hashTableReadIllegalElement() {
-    $c= create('new util.collections.HashTable<string, lang.Object>()');
+    $c= create('new util.collections.HashTable<string, lang.Value>()');
     $c[STDIN];
   }
 
@@ -45,13 +45,13 @@ class ArrayAccessTest extends \unittest\TestCase {
 
   #[@test, @expect(IllegalArgumentException::class)]
   public function hashTableWriteIllegalKey() {
-    $c= create('new util.collections.HashTable<string, lang.Object>()');
+    $c= create('new util.collections.HashTable<string, lang.Value>()');
     $c[STDIN]= new Name('Hello');
   }
 
   #[@test, @expect(IllegalArgumentException::class)]
   public function hashTableWriteIllegalValue() {
-    $c= create('new util.collections.HashTable<string, lang.Object>()');
+    $c= create('new util.collections.HashTable<string, lang.Value>()');
     $c['hello']= 'scalar';
   }
 

--- a/src/test/php/util/collections/unittest/GenericsTest.class.php
+++ b/src/test/php/util/collections/unittest/GenericsTest.class.php
@@ -7,6 +7,7 @@ use util\collections\Stack;
 use util\collections\Queue;
 use util\collections\LRUBuffer;
 use lang\IllegalArgumentException;
+use lang\Value;
 
 /**
  * TestCase
@@ -23,23 +24,23 @@ class GenericsTest extends \unittest\TestCase {
   #[@test]
   public function differingGenericHashTablesNotEquals() {
     $this->assertNotEquals(
-      create('new util.collections.HashTable<lang.Object, lang.Object>'),
-      create('new util.collections.HashTable<util.collections.unittest.Name, lang.Object>')
+      create('new util.collections.HashTable<lang.Value, lang.Value>'),
+      create('new util.collections.HashTable<util.collections.unittest.Name, lang.Value>')
     );
   }
 
   #[@test]
   public function sameGenericHashTablesAreEqual() {
     $this->assertEquals(
-      create('new util.collections.HashTable<util.collections.unittest.Name, lang.Object>'),
-      create('new util.collections.HashTable<util.collections.unittest.Name, lang.Object>')
+      create('new util.collections.HashTable<util.collections.unittest.Name, lang.Value>'),
+      create('new util.collections.HashTable<util.collections.unittest.Name, lang.Value>')
     );
   }
 
   #[@test]
   public function differingGenericHashSetsNotEquals() {
     $this->assertNotEquals(
-      create('new util.collections.HashSet<lang.Object>'),
+      create('new util.collections.HashSet<lang.Value>'),
       create('new util.collections.HashSet<util.collections.unittest.Name>')
     );
   }
@@ -55,7 +56,7 @@ class GenericsTest extends \unittest\TestCase {
   #[@test]
   public function differingGenericVectorsNotEquals() {
     $this->assertNotEquals(
-      create('new util.collections.Vector<lang.Object>'),
+      create('new util.collections.Vector<lang.Value>'),
       create('new util.collections.Vector<util.collections.unittest.Name>')
     );
   }
@@ -71,7 +72,7 @@ class GenericsTest extends \unittest\TestCase {
   #[@test]
   public function differingGenericQueuesNotEquals() {
     $this->assertNotEquals(
-      create('new util.collections.Queue<lang.Object>'),
+      create('new util.collections.Queue<lang.Value>'),
       create('new util.collections.Queue<util.collections.unittest.Name>')
     );
   }
@@ -87,7 +88,7 @@ class GenericsTest extends \unittest\TestCase {
   #[@test]
   public function differingGenericStacksNotEquals() {
     $this->assertNotEquals(
-      create('new util.collections.Stack<lang.Object>'),
+      create('new util.collections.Stack<lang.Value>'),
       create('new util.collections.Stack<util.collections.unittest.Name>')
     );
   }
@@ -103,7 +104,7 @@ class GenericsTest extends \unittest\TestCase {
   #[@test]
   public function differingGenericLRUBuffersNotEquals() {
     $this->assertNotEquals(
-      create('new util.collections.LRUBuffer<lang.Object>', [10]),
+      create('new util.collections.LRUBuffer<lang.Value>', [10]),
       create('new util.collections.LRUBuffer<util.collections.unittest.Name>', [10])
     );
   }
@@ -118,7 +119,7 @@ class GenericsTest extends \unittest\TestCase {
 
   #[@test, @expect(IllegalArgumentException::class)]
   public function nonGenericPassedToCreate() {
-    create('new lang.Object<util.collections.unittest.Name>');
+    create('new lang.Value<util.collections.unittest.Name>');
   }
 
   #[@test]

--- a/src/test/php/util/collections/unittest/HashTableTest.class.php
+++ b/src/test/php/util/collections/unittest/HashTableTest.class.php
@@ -2,7 +2,7 @@
  
 use util\collections\HashTable;
 use util\collections\Pair;
-use lang\Object;
+use lang\Value;
 use lang\IllegalArgumentException;
 use util\Money;
 use util\Currency;
@@ -48,15 +48,17 @@ class HashTableTest extends \unittest\TestCase {
   protected function variations() {
     return [
       [new HashTable()],
-      [create('new util.collections.HashTable<lang.Object, lang.Object>')]
+      [create('new util.collections.HashTable<lang.Value, lang.Value>')]
     ];
   }
 
-  /** @return lang.Object */
+  /** @return lang.Value */
   protected function hashCodeCounter() {
-    return newinstance(Object::class, [], [
-      'invoked'  => 0,
-      'hashCode' => function() { $this->invoked++; return parent::hashCode(); }
+    return newinstance(Value::class, [], [
+      'invoked'   => 0,
+      'toString'  => function() { return 'Test'; },
+      'hashCode'  => function() { $this->invoked++; return 'Test'; },
+      'compareTo' => function($value) { return 0; }
     ]);
   }
 

--- a/src/test/php/util/collections/unittest/Name.class.php
+++ b/src/test/php/util/collections/unittest/Name.class.php
@@ -1,6 +1,6 @@
 <?php namespace util\collections\unittest;
 
-class Name extends \lang\Object {
+class Name implements \lang\Value {
   private $value;
 
   /** @param string $value */
@@ -22,10 +22,10 @@ class Name extends \lang\Object {
    * Returns whether this name is equal to another
    *
    * @param  var $cmp
-   * @return bool
+   * @return int
    */
-  public function equals($cmp) {
-    return $cmp instanceof self && $this->value === $cmp->value;
+  public function compareTo($value) {
+    return $value instanceof self ? strcmp($this->value, $value->value) : 1;
   }
 
   /**

--- a/src/test/php/util/collections/unittest/QueueTest.class.php
+++ b/src/test/php/util/collections/unittest/QueueTest.class.php
@@ -1,5 +1,6 @@
 <?php namespace util\collections\unittest;
  
+use util\Objects;
 use util\collections\Queue;
 use util\NoSuchElementException;
 use lang\IndexOutOfBoundsException;
@@ -103,7 +104,7 @@ class QueueTest extends \unittest\TestCase {
     while (!$this->queue->isEmpty()) {
       $element= $this->queue->get();
 
-      if (!$input[$i]->equals($element)) {
+      if (!Objects::equal($input[$i], $element)) {
         $this->fail('Not equal at offset #'.$i, $element, $input[$i]);
         break;
       }

--- a/src/test/php/util/collections/unittest/VectorTest.class.php
+++ b/src/test/php/util/collections/unittest/VectorTest.class.php
@@ -1,9 +1,9 @@
 <?php namespace util\collections\unittest;
 
-use lang\Object;
 use lang\IllegalArgumentException;
 use lang\IndexOutOfBoundsException;
 use util\collections\Vector;
+use lang\Value;
 
 /**
  * TestCase for vector class
@@ -24,7 +24,7 @@ class VectorTest extends \unittest\TestCase {
   
   #[@test]
   public function nonEmptyVector() {
-    $v= new Vector([new Object()]);
+    $v= new Vector([new Name('Test')]);
     $this->assertEquals(1, $v->size());
     $this->assertFalse($v->isEmpty());
   }
@@ -32,14 +32,14 @@ class VectorTest extends \unittest\TestCase {
   #[@test]
   public function adding() {
     $v= new Vector();
-    $v->add(new Object());
+    $v->add(new Name('Test'));
     $this->assertEquals(1, $v->size());
   }
 
   #[@test]
   public function addAllArray() {
     $v= new Vector();
-    $this->assertTrue($v->addAll([new Object(), new Object()]));
+    $this->assertTrue($v->addAll([new Name('Test'), new Name('Test')]));
     $this->assertEquals(2, $v->size());
   }
 
@@ -47,8 +47,8 @@ class VectorTest extends \unittest\TestCase {
   public function addAllVector() {
     $v1= new Vector();
     $v2= new Vector();
-    $v2->add(new Object());
-    $v2->add(new Object());
+    $v2->add(new Name('Test'));
+    $v2->add(new Name('Test'));
     $this->assertTrue($v1->addAll($v2));
     $this->assertEquals(2, $v1->size());
   }
@@ -56,7 +56,7 @@ class VectorTest extends \unittest\TestCase {
   #[@test]
   public function addAllArrayObject() {
     $v= new Vector();
-    $this->assertTrue($v->addAll(new \ArrayObject([new Object(), new Object()])));
+    $this->assertTrue($v->addAll(new \ArrayObject([new Name('Test'), new Name('Test')])));
     $this->assertEquals(2, $v->size());
   }
 
@@ -77,9 +77,9 @@ class VectorTest extends \unittest\TestCase {
 
   #[@test]
   public function unchangedAfterNullInAddAll() {
-    $v= create('new util.collections.Vector<lang.Object>()');
+    $v= create('new util.collections.Vector<lang.Value>()');
     try {
-      $v->addAll([new Object(), null]);
+      $v->addAll([new Name('Test'), null]);
       $this->fail('addAll() did not throw an exception', null, 'lang.IllegalArgumentException');
     } catch (IllegalArgumentException $expected) {
     }
@@ -99,7 +99,7 @@ class VectorTest extends \unittest\TestCase {
 
   #[@test, @expect(IllegalArgumentException::class)]
   public function addingNull() {
-    create('new util.collections.Vector<lang.Object>()')->add(null);
+    create('new util.collections.Vector<lang.Value>()')->add(null);
   }
 
   #[@test]
@@ -114,17 +114,17 @@ class VectorTest extends \unittest\TestCase {
 
   #[@test, @expect(IllegalArgumentException::class)]
   public function replacingWithNull() {
-    create('new util.collections.Vector<lang.Object>', [new Object()])->set(0, null);
+    create('new util.collections.Vector<lang.Value>', [new Name('Test')])->set(0, null);
   }
 
   #[@test, @expect(IndexOutOfBoundsException::class)]
   public function settingPastEnd() {
-    (new Vector())->set(0, new Object());
+    (new Vector())->set(0, new Name('Test'));
   }
 
   #[@test, @expect(IndexOutOfBoundsException::class)]
   public function settingNegative() {
-    (new Vector())->set(-1, new Object());
+    (new Vector())->set(-1, new Name('Test'));
   }
 
   #[@test]
@@ -181,7 +181,7 @@ class VectorTest extends \unittest\TestCase {
 
   #[@test]
   public function elementsOf() {
-    $el= [new Name('a'), new Object()];
+    $el= [new Name('a'), new Name('Test')];
     $this->assertEquals($el, (new Vector($el))->elements());
   }
 
@@ -195,12 +195,12 @@ class VectorTest extends \unittest\TestCase {
 
   #[@test]
   public function emptyVectorDoesNotContainName() {
-    $this->assertFalse((new Vector())->contains(new Object()));
+    $this->assertFalse((new Vector())->contains(new Name('Test')));
   }
 
   #[@test]
   public function indexOfOnEmptyVector() {
-    $this->assertFalse((new Vector())->indexOf(new Object()));
+    $this->assertFalse((new Vector())->indexOf(new Name('Test')));
   }
 
   #[@test]
@@ -212,12 +212,12 @@ class VectorTest extends \unittest\TestCase {
   #[@test]
   public function indexOfElementContainedTwice() {
     $a= new Name('A');
-    $this->assertEquals(0, (new Vector([$a, new Object(), $a]))->indexOf($a));
+    $this->assertEquals(0, (new Vector([$a, new Name('Test'), $a]))->indexOf($a));
   }
 
   #[@test]
   public function lastIndexOfOnEmptyVector() {
-    $this->assertFalse((new Vector())->lastIndexOf(new Object()));
+    $this->assertFalse((new Vector())->lastIndexOf(new Name('Test')));
   }
 
   #[@test]
@@ -229,7 +229,7 @@ class VectorTest extends \unittest\TestCase {
   #[@test]
   public function lastIndexOfElementContainedTwice() {
     $a= new Name('A');
-    $this->assertEquals(2, (new Vector([$a, new Object(), $a]))->lastIndexOf($a));
+    $this->assertEquals(2, (new Vector([$a, new Name('Test'), $a]))->lastIndexOf($a));
   }
 
   #[@test]
@@ -288,7 +288,7 @@ class VectorTest extends \unittest\TestCase {
 
   #[@test]
   public function twoVectorsOfDifferentSizeAreNotEqual() {
-    $this->assertFalse((new Vector([new Object()]))->equals(new Vector()));
+    $this->assertFalse((new Vector([new Name('Test')]))->equals(new Vector()));
   }
 
   #[@test]


### PR DESCRIPTION
This pull request makes the unittest library compatible with XP9:

* Removes `lang.Object` references, replacing them with dedicated value objects
* Implements `lang.Value` where toString() / hashCode() / comparison are necessary
* Adds `^9.0` to composer.json